### PR TITLE
Use the less flakey yarnpkg gpg key url

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,7 +18,7 @@ class yarn::repo (
           repos    => 'main',
           key      => {
             'id'     => '72ECF46A56B4AD39C907BBB71646B01B86E50310',
-            'server' => 'pgp.mit.edu',
+            'source' => 'https://dl.yarnpkg.com/debian/pubkey.gpg',
           },
         }
 

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -23,7 +23,7 @@ describe 'yarn', :type => :class do
                   .with_repos('main')
                   .with_key({
                     'id'     => '72ECF46A56B4AD39C907BBB71646B01B86E50310',
-                    'server' => 'pgp.mit.edu',
+                    'source' => 'https://dl.yarnpkg.com/debian/pubkey.gpg',
                   })
           }
           it { is_expected.not_to contain_yumrepo('yarn') }


### PR DESCRIPTION
The MIT gpg server is quite flakey.

Basically this implements the corresponding change from https://github.com/yarnpkg/yarn/pull/1598