### PR TITLE
Change to be able to install gpg keys. Related with https://github.com/artberri/puppet-yarn/pull/1

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -11,15 +11,16 @@ class yarn::repo (
       'Debian': {
         include apt
 
+        apt::key {'HEXKEYID':
+          source => 'https://dl.yarnpkg.com/debian/pubkey.gpg',
+          id     => '72ECF46A56B4AD39C907BBB71646B01B86E50310'
+        }
+
         apt::source { 'yarn':
           comment  => 'Yarn source',
           location => 'http://dl.yarnpkg.com/debian/',
           release  => 'stable',
           repos    => 'main',
-          key      => {
-            'id'     => '72ECF46A56B4AD39C907BBB71646B01B86E50310',
-            'server' => 'pgp.mit.edu',
-          },
         }
 
         Apt::Source['yarn'] -> Class['apt::update'] -> Package[$package_name]


### PR DESCRIPTION
Related with https://github.com/artberri/puppet-yarn/pull/1

Change to be able to install gpg keys. If change the server to "https://dl.yarnpkg.com/debian/pubkey.gpg" at apt:source:key:server section I get an error:

Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, validate_re(): "https://dl.yarnpkg.com/debian/pubkey.gpg" does not match ["\\A((hkp|http|https):\\/\\/)?([a-z\\d])([a-z\\d-]{0,61}\\.)+[a-z\\d]+(:\\d{2,5})?$"] (file: /tmp/vagrant-puppet/modules-fd8599149385dcdcc455ce192421ddd5/apt/manifests/key.pp, line: 63, column: 5) (file: /tmp/vagrant-puppet/modules-fd8599149385dcdcc455ce192421ddd5/apt/manifests/source.pp, line: 144

With this change everything works fine.